### PR TITLE
Fix build issues.

### DIFF
--- a/src/nodehun.cpp
+++ b/src/nodehun.cpp
@@ -2,6 +2,7 @@
 #include "nodehun.hpp"
 #include <iostream>
 #include <string.h>
+#include <stdlib.h>
 
 using namespace v8;
 
@@ -80,7 +81,7 @@ Handle<Value> Nodehun::SpellDictionary::New(const Arguments& args) {
 
   String::Utf8Value arg0(args[0]->ToString());
   Nodehun::SpellDictionary * obj;
-  if(argl == 1 || argl > 1 && !args[1]->IsString()){    
+  if(argl == 1 || (argl > 1 && !args[1]->IsString())){    
     obj = new Nodehun::SpellDictionary(*arg0);
     if(!obj->pathsExist)
       return ThrowException(Exception::TypeError(String::New("No such dictionary exists.")));


### PR DESCRIPTION
This fixes node-gyp build failure:

  CXX(target) Release/obj.target/nodehun/nodehun.o
../nodehun.cpp: In static member function ‘static v8::Handlev8::Value Nodehun::SpellDictionary::New(const v8::Arguments&)’:
../nodehun.cpp:83: warning: suggest parentheses around ‘&&’ within ‘||’
../nodehun.cpp: In static member function ‘static v8::Handlev8::Value Nodehun::SpellDictionary::addDictionary(const v8::Arguments&)’:
../nodehun.cpp:231: error: ‘malloc’ was not declared in this scope
../nodehun.cpp: In static member function ‘static void Nodehun::SpellDictionary::addDictionaryFinish(uv_work_t_, int)’:
../nodehun.cpp:269: error: ‘free’ was not declared in this scope
make: *_\* [Release/obj.target/nodehun/nodehun.o] Error 1
make: Leaving directory `/usr/lib/node_modules/nodehun/src/build'
gyp ERR! build error 
gyp ERR! stack Error:`make` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit (/usr/lib/node_modules/node-gyp/lib/build.js:267:23)
gyp ERR! stack     at ChildProcess.EventEmitter.emit (events.js:98:17)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (child_process.js:789:12)
gyp ERR! System Linux 2.6.32-358.14.1.el6.x86_64
gyp ERR! command "node" "/usr/bin/node-gyp" "build"
gyp ERR! cwd /usr/lib/node_modules/nodehun/src
gyp ERR! node -v v0.10.21
gyp ERR! node-gyp -v v0.10.6
gyp ERR! not ok
