### PR TITLE
allow configurable dictionary path

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -18,6 +18,11 @@ var nativeNodeHun		=	require('./../src/build/Release/nodehun'),
 // Initializations that need to take place
 nativeNodeHun._setDictionariesPath(dictionariesPath);
 
+
+exports.setDictionaryPath = function(newPath) {
+  nativeNodeHun._setDictionariesPath(newPath);
+};
+
 // Set all public methods to be exposed
 while(i--){
 	key = nativeKeys[i];


### PR DESCRIPTION
I would prefer to have the dictionary files in a configurable location.  I don't like to check files in the node_modules folder into my version control system.
