### PR TITLE
This change adds the missing hunspell function for add-with-affix.

### DIFF
--- a/examples/l_addWordAffix.js
+++ b/examples/l_addWordAffix.js
@@ -1,0 +1,44 @@
+var debugFlag = process.argv.indexOf('debug') > -1;
+var nodehun = require('./../build/' + (debugFlag ? 'Debug' : 'Release') + '/nodehun');
+var fs = require('fs');
+//var mctime = require('microtime');
+unit = typeof mctime !== "undefined" ? "μs":"ms",
+time = typeof mctime !== "undefined" ? mctime.now : Date.now;
+var affbuf = fs.readFileSync(__dirname+'/dictionaries/en_US.aff');
+var dictbuf = fs.readFileSync(__dirname+'/dictionaries/en_US.dic');
+
+var dict = new nodehun(affbuf,dictbuf);
+console.log('"colour" before addition sync:', dict.spellSuggestSync('colour'));
+dict.addWordSync('colour');
+console.log('"colour" after addition sync:', dict.spellSuggestSync('colour'));
+
+var timeInit = time();
+dict = new nodehun(affbuf,dictbuf);
+
+dict.spellSuggest('colour', function (err, a, b, c) {
+    if (!err)
+        console.log('"colour" without addition', a, b, c);
+    var timeWord = time();
+    dict.addWordWithAffix('colour', 'color', function (err, a, b) {
+        if (!err)
+            console.log(err);
+        console.log('time adding word:', time() - timeWord, unit);
+        console.log('added word:', a, b);
+        dict.spellSuggest('colours', function (err, a, b, c) {
+            if (!err)
+                console.log('"colours" with addition', a, b, c)
+        });
+        dict.spellSuggest('coloursi', function (err, a, b, c) {
+            if (!err)
+                console.log('"coloursi" with addition', a, b, c)
+        });
+        dict.spellSuggest('coloring', function (err, a, b, c) {
+            if (!err)
+                console.log('"coloring" with addition', a, b, c)
+        });
+        dict.spellSuggest('colouring', function (err, a, b, c) {
+            if (!err)
+                console.log('"colouring" with addition', a, b, c)
+        });
+    });
+});

--- a/src/post0.12.0/nodehun.hpp
+++ b/src/post0.12.0/nodehun.hpp
@@ -40,6 +40,20 @@ namespace Nodehun {
     std::string word;
     Nodehun::SpellDictionary* obj;
   };
+
+  //{{HM
+  struct WordData2 {
+	  uv_work_t request;
+	  v8::Persistent<v8::Function> callback;
+	  v8::Isolate* isolate;
+	  bool callbackExists;
+	  bool success;
+	  std::string word;
+	  std::string example;
+	  Nodehun::SpellDictionary* obj;
+  };
+  //}}
+
   //
   // represents a work baton to asynchronously add a new
   // new dictionary, during runtime, to the object of 
@@ -196,6 +210,15 @@ protected:
   static void addRemoveWordWork(uv_work_t*);  
   static void addRemoveWordFinish(uv_work_t*, int i = -1);
   bool addRemoveWord(const char*, bool);
+  //{{HM
+  static void addWordWithAffix(const FunctionCallbackInfo<Value>&);
+  static void addWordWithAffixSync(const FunctionCallbackInfo<Value>&);
+  static void addWordWithAffixInit(const FunctionCallbackInfo<Value>&);
+  static void addWordWithAffixInitSync(const FunctionCallbackInfo<Value>&);
+  static void addWordWithAffixWork(uv_work_t* request);
+  static void addWordWithAffixFinish(uv_work_t* request, int i);
+  bool addWordWithAffix(const char*, const char*);
+  //}}
   //
   // node wrapped hunspell stem function
   //


### PR DESCRIPTION
Some languages have high degree of inflections, and adding a new root word amounts to several hundred inflections of the root word. Without an add-word-with-affix feature, will require a lot of extra effort by user. The current PR function is a life savior in this case. So, please merge into the master. 
Thanks
Haro