### PR TITLE
Delete unused shared_mutex

### DIFF
--- a/src/HunspellContext.h
+++ b/src/HunspellContext.h
@@ -4,7 +4,6 @@
 #include <hunspell.hxx>
 #include <napi.h>
 #include <mutex>
-#include <shared_mutex>
 #include <uv.h>
 
 class HunspellContext {


### PR DESCRIPTION
After 

> [Switch from std::shared_mutex to libuv's uv_rwlock](https://github.com/Wulf/nodehun/commit/98387099470e2909fabc63c392b034424be13584)

shared_mutex not used.